### PR TITLE
Fixing bug when skiping Bootstrap

### DIFF
--- a/app/rf-helper.js
+++ b/app/rf-helper.js
@@ -87,7 +87,7 @@ module.exports = generators.Base.extend({
     var scriptSuffix = this.config.get('scriptSuffix');
     var dialectTest = (scriptSuffix === '.js') ? '.jsx?' : scriptSuffix;
     var bootstrap = this.config.get('withBootstrap') ? "Bootstrap" : "";
-    var bootstrapLoaders = this.config.get('withBootstrap') ? loaders['BootstrapLoaders'] : {};
+    var bootstrapLoaders = this.config.get('withBootstrap') ? loaders['BootstrapLoaders'] : '';
     var dialectLoader = loaders.get(dialect);
 
     this.config.set('bootstrapLoaders',bootstrapLoaders);


### PR DESCRIPTION
Sorry... I couldn't figure it out how to test this issue...

The config file was being generated with a "{}" where bootstrap loader was supposed to be if it was not being skipped. So I change it for an empty string instead.