### PR TITLE
Renamed node-stylus dep to stylus

### DIFF
--- a/app/options/dependencies.js
+++ b/app/options/dependencies.js
@@ -58,7 +58,7 @@ module.exports = {
   },
 
   StylusDependencies: {
-    'node-stylus': '*',
+    'stylus': '*',
     'stylus-loader': '*'
   },
 


### PR DESCRIPTION
`node-stylus` is `stylus` now
```
npm ERR! 404 Registry returned 404 for GET on https://registry.npmjs.org/node-stylus
npm ERR! 404
npm ERR! 404 'node-stylus' is not in the npm registry.
```